### PR TITLE
list all cells used

### DIFF
--- a/ckt_cmds.cc
+++ b/ckt_cmds.cc
@@ -297,6 +297,17 @@ static int process_cell_map (int argc, char **argv)
   else {
     printf ("%s: cell pass already executed; skipped\n", argv[0]);
   }
+  // display cell stats both on a fresh run and when called again
+  list_t *l;
+  l = cp->getUsedCells ();
+  if (list_length (l) > 0) {
+    printf ("INFO: the following cells are used in the design:\n");
+    for (listitem_t *li = list_first (l); li; li = list_next (li)) {
+	  printf ("   %s\n", ((Process *)list_value (li))->getName());
+    }
+  }
+  printf ("   Number of unique cells: %d ", list_length (l));
+
   F.cell_map = 1;
   return LISP_RET_TRUE;
 }


### PR DESCRIPTION
This adds the info of which cells are used by a design,

Ideally to be even more useful it should print how often each cell appears in the hierarchy,

to do this dumbly (and inefficiently) I could first rise in the hierarchy for the first cell with getParent then on the top node traverse all nodes. When a UsrType says it's a leaf -> ask it if it's a process, then ask it if it's a cell, ask it which cell of the list, and increment a counter. There might be a more efficient way.
