### PR TITLE
add the ability to define a fixed size (bounding box) in lambda for phydb initialisation

### DIFF
--- a/scripts/phydb.scm
+++ b/scripts/phydb.scm
@@ -40,6 +40,22 @@
        )
      )
 
+	(define phydb:create_bb			; populate phydb
+     (lambda (bb_x bb_y lefout)
+       (begin
+	 (phydb:init)
+	 (act:layout:create)
+	 (act:layout:lef "_out.lef" "_out.cell")
+	 (act:layout:def_bb "_out.def" #t bb_x bb_y)
+	 (phydb:read-lef "_out.lef")
+	 (phydb:read-cell "_out.cell")
+	 (phydb:read-def "_out.def")
+	 (system "rm _out.def _out.cell")
+	 (system (string-append "mv _out.lef " lefout))
+	 )
+       )
+     )
+
    (define phydb:create-stdcell		; populate phydb
      (lambda (area ratio lef_list)
        (begin

--- a/scripts/stk-pass.scm
+++ b/scripts/stk-pass.scm
@@ -75,6 +75,23 @@
 	  )
 	)
 
+	(define act:layout:def_bb
+	(lambda (def pins? x y)
+	  (let ((f (sys:open def "w")))
+	    (begin
+	      (ckt:mk-nets)
+	      (act:pass:set_file "stk2layout" "def_file" f)
+	      (act:pass:set_int "stk2layout" "do_pins" (if pins? 1 0))
+		  (act:pass:set_int "stk2layout" "is_bb" 1)
+	      (act:pass:set_real "stk2layout" "bb_x" x)
+	      (act:pass:set_real "stk2layout" "bb_y" y)
+	      (act:layout:run 5)
+	      (sys:close f)
+	      )
+	    )
+	  )
+	)
+
       (define round3 (lambda (x) (/ (truncate (+ (* x 1000) 0.5)) 1000.0)))
       
       (define act:layout:report
@@ -163,6 +180,21 @@
 	    )
 	   )
 	  )
+(help-add "act:layout:def_bb"
+    "Generate DEF file with defined size with ACT netlist in DEF format"
+	  (string-multiappend
+	   (list
+	    ">  Usage: (act:layout:def def-file pins? x y)"
+	    ">    def-file - the output file name"
+	    ">       pins? - #t or #f if pins should be generated"
+	    ">   x - the x dimension in lambda of the bounding box to be created (it will snap the the next smaller track definition)"
+	    ">    y - the y dimension in lambda of the bounding box to be created (it will snap the the next smaller track definition)"
+	    "|    act:layout:create must be called before this function can be used."
+	    "|    Normally this function is called by phydb:create_bb rather than directly."
+	    ""
+	    )
+	   )
+	  )  
 
 (help-add "act:layout:report"
     "Print out area report and break-down"


### PR DESCRIPTION
this is needed for the hirachical tapeout flow

added phydb:create_bb for initalising a db with a fixed size
added act:layout:def_bb for writing def with fixed bb size

requires https://github.com/rmanohar/layout/pull/9